### PR TITLE
feat: プロンプトのKubernetes/GCP情報をトグルする機能を追加

### DIFF
--- a/.zshrc.alias
+++ b/.zshrc.alias
@@ -19,6 +19,13 @@ function cwaf() {
 # ls
 alias ll="ls -la"
 
+# Powerline prompt toggle commands
+# These are also defined as functions in .zshrc.prompt
+# Adding aliases for convenience
+alias k8s-info='k8s-toggle'
+alias gcp-info='gcp-toggle'
+alias prompt-info='prompt-toggle'
+
 # process
 alias 'ps?'='pgrep -l -f'
 

--- a/.zshrc.prompt
+++ b/.zshrc.prompt
@@ -1,5 +1,33 @@
 function powerline_precmd() {
-    PS1="$(powerline-shell.py $? --shell zsh 2> /dev/null)"
+    local powerline_output="$(powerline-shell.py $? --shell zsh 2> /dev/null)"
+    
+    # K8S情報のフィルタリング
+    if [[ -n "$POWERLINE_K8S_HIDE" ]]; then
+        # K8Sセグメント（⎈マークを含む行）を除外し、最初の改行も調整
+        local lines=()
+        local skip_next_newline=0
+        while IFS= read -r line; do
+            if [[ "$line" == *"⎈"* ]]; then
+                skip_next_newline=1
+                continue
+            fi
+            if [[ $skip_next_newline -eq 1 && -z "$line" ]]; then
+                skip_next_newline=0
+                continue
+            fi
+            lines+=("$line")
+        done <<< "$powerline_output"
+        powerline_output=$(printf '%s\n' "${lines[@]}")
+    fi
+    
+    # GCP情報のフィルタリング
+    if [[ -n "$POWERLINE_GCP_HIDE" ]]; then
+        # GCPセグメント（GCP:を含む部分）を除外
+        # sedの正規表現を修正して、GCPセグメントのみを削除
+        powerline_output=$(echo "$powerline_output" | sed -E 's/%\{[^}]*\}%\{[^}]*\} GCP: [^%]* %\{[^}]*\}%\{[^}]*\}//g')
+    fi
+    
+    PS1="$powerline_output"
 }
 
 function install_powerline_precmd() {
@@ -14,4 +42,39 @@ function install_powerline_precmd() {
 if [ "$TERM" != "linux" ]; then
     install_powerline_precmd
 fi
+
+# Kubernetes情報の表示/非表示を切り替える関数
+function k8s-toggle() {
+    if [[ -n "$POWERLINE_K8S_HIDE" ]]; then
+        unset POWERLINE_K8S_HIDE
+        echo "Kubernetes情報を表示します"
+    else
+        export POWERLINE_K8S_HIDE=1
+        echo "Kubernetes情報を非表示にします"
+    fi
+}
+
+# GCP情報の表示/非表示を切り替える関数
+function gcp-toggle() {
+    if [[ -n "$POWERLINE_GCP_HIDE" ]]; then
+        unset POWERLINE_GCP_HIDE
+        echo "GCP情報を表示します"
+    else
+        export POWERLINE_GCP_HIDE=1
+        echo "GCP情報を非表示にします"
+    fi
+}
+
+# 両方同時に切り替える関数
+function prompt-toggle() {
+    if [[ -n "$POWERLINE_K8S_HIDE" || -n "$POWERLINE_GCP_HIDE" ]]; then
+        unset POWERLINE_K8S_HIDE
+        unset POWERLINE_GCP_HIDE
+        echo "Kubernetes/GCP情報を表示します"
+    else
+        export POWERLINE_K8S_HIDE=1
+        export POWERLINE_GCP_HIDE=1
+        echo "Kubernetes/GCP情報を非表示にします"
+    fi
+}
 

--- a/docs/powerline-toggle.md
+++ b/docs/powerline-toggle.md
@@ -1,0 +1,74 @@
+# Powerline Shell トグル機能
+
+Powerline Shellのプロンプトに表示されるKubernetes情報とGCP情報を動的に表示/非表示切り替えする機能です。
+
+## 使用方法
+
+### 基本コマンド
+
+#### Kubernetes情報のトグル
+```bash
+k8s-toggle    # 表示/非表示を切り替え
+k8s-info      # エイリアス（同じ動作）
+```
+
+#### GCP情報のトグル
+```bash
+gcp-toggle    # 表示/非表示を切り替え
+gcp-info      # エイリアス（同じ動作）
+```
+
+#### 両方同時にトグル
+```bash
+prompt-toggle # Kubernetes/GCP両方の表示/非表示を切り替え
+prompt-info   # エイリアス（同じ動作）
+```
+
+### 環境変数での制御
+
+以下の環境変数を設定することで、起動時から情報を非表示にできます：
+
+```bash
+# Kubernetes情報を非表示
+export POWERLINE_K8S_HIDE=1
+
+# GCP情報を非表示
+export POWERLINE_GCP_HIDE=1
+
+# 表示に戻す
+unset POWERLINE_K8S_HIDE
+unset POWERLINE_GCP_HIDE
+```
+
+### 永続化
+
+常に非表示にしたい場合は、`~/.zshrc.local`に以下を追加：
+
+```bash
+# Kubernetes情報を常に非表示
+export POWERLINE_K8S_HIDE=1
+
+# GCP情報を常に非表示
+export POWERLINE_GCP_HIDE=1
+```
+
+## 実装詳細
+
+- `powerline-shell.py`は生成物のため直接編集不可
+- `.zshrc.prompt`の`powerline_precmd`関数で出力をフィルタリング
+- K8S情報: ⎈マークを含む行全体を削除
+- GCP情報: GCPセグメントのみを削除（行は維持）
+
+## トラブルシューティング
+
+### 設定が反映されない場合
+```bash
+source ~/.zshrc
+```
+
+### 動作確認
+```bash
+# 現在の環境変数を確認
+echo "K8S_HIDE: $POWERLINE_K8S_HIDE"
+echo "GCP_HIDE: $POWERLINE_GCP_HIDE"
+```


### PR DESCRIPTION
## Summary
- Powerline Shellプロンプトに表示されるKubernetes情報とGCP情報を動的に表示/非表示切り替えする機能を追加
- 環境変数による制御でpowerline-shell.pyを直接編集せずに実装
- トグルコマンドで簡単に切り替え可能

## 変更内容
- `.zshrc.prompt`: powerline_precmd関数を修正し、環境変数による出力フィルタリングを実装
- `.zshrc.alias`: トグルコマンドのエイリアスを追加
- `docs/powerline-toggle.md`: 使用方法のドキュメントを作成

## 使用方法
```bash
# Kubernetes情報のトグル
k8s-toggle

# GCP情報のトグル
gcp-toggle

# 両方同時にトグル
prompt-toggle
```

## Test plan
- [x] k8s-toggleでKubernetes情報の表示/非表示が切り替わることを確認
- [x] gcp-toggleでGCP情報の表示/非表示が切り替わることを確認
- [x] prompt-toggleで両方同時に切り替わることを確認
- [x] 環境変数を直接設定しても動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)