### PR TITLE
chore(sgpt): bump model to gpt-5.5-2026-04-23

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -81,7 +81,7 @@ if [[ -n "$BUFFER" ]]; then
     _sgpt_prev_cmd=$BUFFER
     BUFFER+="⌛"
     zle -I && zle redisplay
-    BUFFER=$(sgpt --shell --model gpt-5.2-2025-12-11 <<< "$_sgpt_prev_cmd" --no-interaction)
+    BUFFER=$(sgpt --shell --model gpt-5.5-2026-04-23 <<< "$_sgpt_prev_cmd" --no-interaction)
     zle end-of-line
 fi
 }

--- a/.zshrc.alias
+++ b/.zshrc.alias
@@ -204,7 +204,7 @@ alias ls="eza --no-user --icons --git -la --long --header"
 alias olog="olog.sh"
 
 function chkerr() {
-    rm "$(sgpt --list-chats --model gpt-5.2-2025-12-11|grep checkerror)"
+    rm "$(sgpt --list-chats --model gpt-5.5-2026-04-23|grep checkerror)"
     (tee /dev/tty ; echo -e "\033[31m==========================診断結果です===============================\033[0m" > /dev/tty) | sgpt --chat checkerror "check logs, find errors, provide possible solutions, もしエラーが見つからない場合は問題は「見つからなかった」とだけ簡潔に伝えてください, 日本語で回答すること。文書の末尾にあなたのモデル名を答えること。"
 }
 

--- a/bin/chkrun
+++ b/bin/chkrun
@@ -1,7 +1,7 @@
 #!/bin/bash
 # require installing https://github.com/TheR1D/shell_gpt
 function chkerr() {
-    rm "$(sgpt --list-chats --model gpt-5.2-2025-12-11|grep checkerror)"
+    rm "$(sgpt --list-chats --model gpt-5.5-2026-04-23|grep checkerror)"
     (tee /dev/tty ; echo -e "\033[31m==========================診断結果です===============================\033[0m" > /dev/tty) | sgpt --chat checkerror "check logs, find errors, provide possible solutions, もしエラーが見つからない場合は問題は「見つからなかった」とだけ簡潔に伝えてください"
 }
 


### PR DESCRIPTION
## 概要

sgpt で利用しているモデル ID を最新の公式 dated snapshot に更新する。

## 変更点

- `.zshrc`: Ctrl+X バインドの sgpt モデルを `gpt-5.2-2025-12-11` → `gpt-5.5-2026-04-23`
- `.zshrc.alias`: `chkerr` 関数内の sgpt モデルを同様に更新
- `bin/chkrun`: `chkerr` 関数内の sgpt モデルを同様に更新

## 動作確認

- [ ] 新しい zsh セッションを起動し、Ctrl+X で sgpt がコマンド生成できる
- [ ] `chkerr` 関数経由で sgpt がエラー診断できる