### PR TITLE
fix(nvim): map M-backslash to literal backslash for JIS yen key hack

### DIFF
--- a/lua/edit.lua
+++ b/lua/edit.lua
@@ -11,6 +11,11 @@ vim.api.nvim_create_autocmd("InsertLeave", {
   command = "set iminsert=0"
 })
 
+-- Karabiner「Change ¥ to Alt+¥」ハック対策
+-- 端末がOptionをMetaとして送ると¥キーが<M-\>として届き、未マップのALTコードは
+-- Esc+キー扱いでinsert/cmdlineモードが解除される(:help i_ALT, c_ALT)ため、素の \ にマップする
+vim.keymap.set({ 'i', 'c' }, '<M-Bslash>', '<Bslash>', { noremap = true })
+
 -- Tabキーを空白に変換
 vim.opt.expandtab = true
 


### PR DESCRIPTION
## 概要
JIS キーボード + Karabiner「Change ¥ to Alt+¥」ハック環境で、Neovim の検索・置換プロンプト（cmdline モード）や insert モードで ¥（バックスラッシュ）を入力するとモードが解除される問題を修正。

## 原因
端末が Option を Meta として送ると ¥ キーが `<M-\>` として届き、未マップの ALT コードは `<Esc>` + キー扱いになる Neovim の仕様（`:help i_ALT` / `:help c_ALT`）により、モードが解除されていた。

## 対応
`<M-Bslash>` を insert / cmdline 両モードで素の `\` にマッピング。

## テスト
- [x] headless 起動で `c` / `i` 両モードのマッピングロードを確認
- [x] 実機で `/` 検索プロンプト・`:%s` 置換に `\` が入力できることを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
